### PR TITLE
Block PR creation when secret scanner finds private data in pending changes (#82)

### DIFF
--- a/src/workflows/issue-pipeline.security-gate.test.ts
+++ b/src/workflows/issue-pipeline.security-gate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { execSync } from "node:child_process";
+import { IssuePipeline, type CodeAgent, type IssueContext } from "./issue-pipeline";
+import type { Ticket } from "../connectors/types";
+
+describe("IssuePipeline security gate integration", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tz-security-gate-"));
+    execSync("git init", { cwd: dir, stdio: "pipe" });
+    execSync('git config user.email "zara@example.com"', { cwd: dir, stdio: "pipe" });
+    execSync('git config user.name "Zara"', { cwd: dir, stdio: "pipe" });
+    mkdirSync(join(dir, "src"), { recursive: true });
+    writeFileSync(join(dir, "src", "index.ts"), "export const hello = 'world';\n", "utf-8");
+    execSync("git add .", { cwd: dir, stdio: "pipe" });
+    execSync('git commit -m "init"', { cwd: dir, stdio: "pipe" });
+    execSync("git branch -M main", { cwd: dir, stdio: "pipe" });
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("fails before PR creation when pending changes contain a secret", async () => {
+    const issueComments: string[] = [];
+    let createPRCalls = 0;
+
+    const fakeTicket: Ticket = {
+      id: 82,
+      number: 82,
+      title: "Block PR creation when secret scanner finds private data in pending changes",
+      body: "Add a pre-PR secret gate.",
+      labels: ["tierzero-agent", "priority-1"],
+      assignees: [],
+      author: "ellistev",
+      state: "open",
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      url: "https://github.com/ellistev/tierzero/issues/82",
+    };
+
+    const codeAgent: CodeAgent = {
+      async solve(_issue: IssueContext, workDir: string) {
+        writeFileSync(
+          join(workDir, "src", "leak.ts"),
+          'export const token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";\n',
+          "utf-8",
+        );
+        return { summary: "Introduced a secret-bearing file", filesChanged: ["src/leak.ts"] };
+      },
+      async fixTests() {
+        return { summary: "no-op", filesChanged: [] };
+      },
+      async fixReviewFindings() {
+        return { summary: "no-op", filesChanged: [] };
+      },
+    };
+
+    const pipeline = new IssuePipeline({
+      github: {
+        addComment: async (_issueId: number, body: string) => { issueComments.push(body); },
+        addLabel: async () => {},
+        removeLabel: async () => {},
+        updateIssueState: async () => {},
+      } as any,
+      prConfig: {
+        githubToken: "fake-token",
+        owner: "ellistev",
+        repo: "tierzero",
+      },
+      workDir: dir,
+      codeAgent,
+      testCommand: "node -e \"process.exit(0)\"",
+      logger: { log: () => {}, error: () => {} },
+    });
+
+    (pipeline as any).pr = {
+      createPR: async () => {
+        createPRCalls++;
+        return { number: 999, url: "https://example.com/pr/999" };
+      },
+      commentOnPR: async () => {},
+      mergePR: async () => {},
+    };
+
+    const result = await pipeline.run(fakeTicket);
+
+    assert.equal(result.status, "failed");
+    assert.equal(result.prNumber, undefined);
+    assert.equal(createPRCalls, 0);
+    assert.ok(issueComments.some((c) => c.includes("blocked PR creation")));
+    assert.ok(issueComments.some((c) => c.includes("github-token")));
+  });
+});

--- a/src/workflows/issue-pipeline.test.ts
+++ b/src/workflows/issue-pipeline.test.ts
@@ -1,6 +1,10 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { parseTestOutput } from "./issue-pipeline";
+import { checkStagedFiles } from "../security/pre-commit-check";
 
 describe("parseTestOutput", () => {
   it("parses node:test output with all passing", () => {
@@ -66,5 +70,26 @@ describe("parseTestOutput", () => {
     assert.equal(result.total, 263);
     assert.equal(result.passing, 263);
     assert.equal(result.failing, 0);
+  });
+});
+
+describe("pre-PR secret gate", () => {
+  it("passes clean changed files", () => {
+    const result = checkStagedFiles(["src/workflows/issue-pipeline.ts"]);
+    assert.equal(result.passed, true);
+  });
+
+  it("flags secret-bearing pending files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "tierzero-secret-gate-"));
+    const file = join(dir, "pending-secret.ts");
+
+    try {
+      writeFileSync(file, 'const token = "ghp_abcdefghijklmnopqrstuvwxyz1234567890";\n', "utf-8");
+      const result = checkStagedFiles([file]);
+      assert.equal(result.passed, false);
+      assert.ok(result.findings.length > 0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/workflows/issue-pipeline.ts
+++ b/src/workflows/issue-pipeline.ts
@@ -19,6 +19,7 @@ import { StartPipeline, CompleteAgentWork, RecordTestRun, RecordTestFix, CreateP
 import type { IEventStore, ESEventData } from "../infra/interfaces";
 import type { Deployer, DeployConfig, DeployResult } from "../deploy/deployer";
 import { createLogger } from "../infra/logger";
+import { checkStagedFiles } from "../security/pre-commit-check";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -395,6 +396,28 @@ export class IssuePipeline {
         await this.emitEvents(streamId, aggregate, failEvents);
 
         await this.config.github.addComment(ticket.id, "TierZero produced no committed changes, so no PR was created.");
+        this.git.resetToMain();
+        return result;
+      }
+
+      const secretCheck = checkStagedFiles(changedFilesForPr);
+      if (!secretCheck.passed) {
+        result.status = "failed";
+        result.error = "Secret scan failed before PR creation";
+
+        const failEvents = aggregate.execute(
+          new FailPipeline(pipelineId, result.error, new Date().toISOString())
+        );
+        await this.emitEvents(streamId, aggregate, failEvents);
+
+        const findingsSummary = secretCheck.findings
+          .map((f) => `- \`${f.file}:${f.line}\` ${f.pattern} (${f.match})`)
+          .join("\n");
+
+        await this.config.github.addComment(
+          ticket.id,
+          `TierZero blocked PR creation because the pending changes tripped the secret scanner.\n\n${findingsSummary}`,
+        );
         this.git.resetToMain();
         return result;
       }


### PR DESCRIPTION
Closes #82

## Summary
- add a hard pre-PR secret gate in the issue pipeline
- fail the pipeline before PR creation when pending changed files trip the secret scanner
- post a clear issue comment with blocked findings summary
- add tests for clean files and secret-bearing pending files

## Files
- `src/workflows/issue-pipeline.ts`
- `src/workflows/issue-pipeline.test.ts`

## Tests
- `npm test` -> 1018/1018 passing

---
*Pipeline-level safety gate so no PR gets opened with obvious secrets/private data patterns.*